### PR TITLE
Update BMA colours and fix function builder for complexes

### DIFF
--- a/casq/bmaExport.py
+++ b/casq/bmaExport.py
@@ -156,6 +156,7 @@ def get_relationships(info, idMap, count, granularity, ignoreSelfLoops):
                     pass
             # now modifiers
             if len(transition[2]) == 0:
+                formula.finishTransition()
                 continue
             modifiers = transition[2]
             # catalysts are a special case

--- a/casq/bmaExport.py
+++ b/casq/bmaExport.py
@@ -104,11 +104,14 @@ class multiStateFormulaBuilder:
         pass
 
 
+# hardcoded colour codes so elements still follow BMA colourscheme
+# Default pink #ff66cc
 COLOURMAP = {
-    0: "BMA_Green",
-    1: "BMA_Orange",
-    2: "BMA_Purple",
-    3: "BMA_Mint",
+    0: "#ff66cc",
+    1: "#33cc00",
+    2: "#ff9900",
+    3: "#9966ff",
+    4: "#00cccc"
 }
 
 


### PR DESCRIPTION
Two fixes in this PR

Colours have been updated to match "internal" defaults, following designer feedback

Complex function building was broken due to issues arising from model simplification